### PR TITLE
Add support for dynamic content of variants

### DIFF
--- a/lib/CoreExperiment.js
+++ b/lib/CoreExperiment.js
@@ -26,22 +26,28 @@ exports.default = _react2.default.createClass({
   displayName: "Pushtell.CoreExperiment",
   propTypes: {
     name: _react2.default.PropTypes.string.isRequired,
+    isContentDynamic: _react2.default.PropTypes.bool,
     value: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.string, _react2.default.PropTypes.func]).isRequired
   },
   win: function win() {
     _emitter2.default.emitWin(this.props.name);
   },
+  getDefaultProps: function getDefaultProps() {
+    return {
+      isContentDynamic: false
+    };
+  },
   getInitialState: function getInitialState() {
     var _this = this;
 
     var children = {};
-    _react2.default.Children.forEach(this.props.children, function (element) {
+    _react2.default.Children.forEach(this.props.children, function (element, index) {
       if (!_react2.default.isValidElement(element) || element.type.displayName !== "Pushtell.Variant") {
         var error = new Error("Pushtell Experiment children must be Pushtell Variant components.");
         error.type = "PUSHTELL_INVALID_CHILD";
         throw error;
       }
-      children[element.props.name] = element;
+      children[element.props.name] = _this.props.isContentDynamic ? index : element;
       _emitter2.default.addExperimentVariant(_this.props.name, element.props.name);
     });
     _emitter2.default.emit("variants-loaded", this.props.name);
@@ -83,6 +89,13 @@ exports.default = _react2.default.createClass({
     this.valueSubscription.remove();
   },
   render: function render() {
+    if (this.props.isContentDynamic) {
+      if (Array.isArray(this.props.children)) {
+        var index = this.state.variants[this.state.value];
+        return index !== undefined ? this.props.children[index] : null;
+      }
+      return this.props.children || null;
+    }
     return this.state.variants[this.state.value] || null;
   }
 });

--- a/lib/Experiment.js
+++ b/lib/Experiment.js
@@ -59,6 +59,7 @@ exports.default = _react2.default.createClass({
   displayName: "Pushtell.Experiment",
   propTypes: {
     name: _react2.default.PropTypes.string.isRequired,
+    isContentDynamic: _react2.default.PropTypes.bool,
     defaultVariantName: _react2.default.PropTypes.string,
     userIdentifier: _react2.default.PropTypes.string
   },

--- a/src/CoreExperiment.jsx
+++ b/src/CoreExperiment.jsx
@@ -72,7 +72,7 @@ export default React.createClass({
     if (this.props.isContentDynamic) {
       if (Array.isArray(this.props.children)) {
         const index = this.state.variants[this.state.value];
-        return index ? this.props.children[index] : null;
+        return index !== undefined ? this.props.children[index] : null;
       }
       return this.props.children || null;
     }

--- a/src/CoreExperiment.jsx
+++ b/src/CoreExperiment.jsx
@@ -7,6 +7,7 @@ export default React.createClass({
   displayName: "Pushtell.CoreExperiment",
   propTypes: {
     name: React.PropTypes.string.isRequired,
+    isContentDynamic: React.PropTypes.bool,
     value: React.PropTypes.oneOfType([
       React.PropTypes.string,
       React.PropTypes.func
@@ -15,15 +16,20 @@ export default React.createClass({
   win(){
     emitter.emitWin(this.props.name);
   },
+  getDefaultProps() {
+    return {
+      isContentDynamic: false
+    };
+  },
   getInitialState(){
     let children = {};
-    React.Children.forEach(this.props.children, element => {
+    React.Children.forEach(this.props.children, (element, index) => {
       if(!React.isValidElement(element) || element.type.displayName !== "Pushtell.Variant"){
         let error = new Error("Pushtell Experiment children must be Pushtell Variant components.");
         error.type = "PUSHTELL_INVALID_CHILD";
         throw error;
       }
-      children[element.props.name] = element;
+      children[element.props.name] = this.props.isContentDynamic ? index : element;
       emitter.addExperimentVariant(this.props.name, element.props.name);
     });
     emitter.emit("variants-loaded", this.props.name);
@@ -63,6 +69,13 @@ export default React.createClass({
     this.valueSubscription.remove();
   },
   render(){
+    if (this.props.isContentDynamic) {
+      if (Array.isArray(this.props.children)) {
+        const index = this.state.variants[this.state.value];
+        return index ? this.props.children[index] : null;
+      }
+      return this.props.children || null;
+    }
     return this.state.variants[this.state.value] || null;
   }
 });

--- a/src/Experiment.jsx
+++ b/src/Experiment.jsx
@@ -38,6 +38,7 @@ export default React.createClass({
   displayName: "Pushtell.Experiment",
   propTypes: {
     name: React.PropTypes.string.isRequired,
+    isContentDynamic: React.PropTypes.bool,
     defaultVariantName: React.PropTypes.string,
     userIdentifier: React.PropTypes.string
   },

--- a/standalone.min.js
+++ b/standalone.min.js
@@ -48,11 +48,11 @@
 
 	module.exports = {
 	  Experiment: __webpack_require__(1),
-	  Variant: __webpack_require__(17),
+	  Variant: __webpack_require__(16),
 	  emitter: __webpack_require__(8),
-	  experimentDebugger: __webpack_require__(20),
-	  mixpanelHelper: __webpack_require__(24),
-	  segmentHelper: __webpack_require__(26)
+	  experimentDebugger: __webpack_require__(19),
+	  mixpanelHelper: __webpack_require__(23),
+	  segmentHelper: __webpack_require__(25)
 	};
 
 /***/ },
@@ -88,7 +88,7 @@
 
 	var _emitter2 = _interopRequireDefault(_emitter);
 
-	var _crc = __webpack_require__(19);
+	var _crc = __webpack_require__(18);
 
 	var _crc2 = _interopRequireDefault(_crc);
 
@@ -129,6 +129,7 @@
 	  displayName: "Pushtell.Experiment",
 	  propTypes: {
 	    name: _react2.default.PropTypes.string.isRequired,
+	    isContentDynamic: _react2.default.PropTypes.bool,
 	    defaultVariantName: _react2.default.PropTypes.string,
 	    userIdentifier: _react2.default.PropTypes.string
 	  },
@@ -200,7 +201,7 @@
 
 	var _emitter2 = _interopRequireDefault(_emitter);
 
-	var _Variant = __webpack_require__(17);
+	var _Variant = __webpack_require__(16);
 
 	var _Variant2 = _interopRequireDefault(_Variant);
 
@@ -212,22 +213,28 @@
 	  displayName: "Pushtell.CoreExperiment",
 	  propTypes: {
 	    name: _react2.default.PropTypes.string.isRequired,
+	    isContentDynamic: _react2.default.PropTypes.bool,
 	    value: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.string, _react2.default.PropTypes.func]).isRequired
 	  },
 	  win: function win() {
 	    _emitter2.default.emitWin(this.props.name);
 	  },
+	  getDefaultProps: function getDefaultProps() {
+	    return {
+	      isContentDynamic: false
+	    };
+	  },
 	  getInitialState: function getInitialState() {
 	    var _this = this;
 
 	    var children = {};
-	    _react2.default.Children.forEach(this.props.children, function (element) {
+	    _react2.default.Children.forEach(this.props.children, function (element, index) {
 	      if (!_react2.default.isValidElement(element) || element.type.displayName !== "Pushtell.Variant") {
 	        var error = new Error("Pushtell Experiment children must be Pushtell Variant components.");
 	        error.type = "PUSHTELL_INVALID_CHILD";
 	        throw error;
 	      }
-	      children[element.props.name] = element;
+	      children[element.props.name] = _this.props.isContentDynamic ? index : element;
 	      _emitter2.default.addExperimentVariant(_this.props.name, element.props.name);
 	    });
 	    _emitter2.default.emit("variants-loaded", this.props.name);
@@ -269,6 +276,13 @@
 	    this.valueSubscription.remove();
 	  },
 	  render: function render() {
+	    if (this.props.isContentDynamic) {
+	      if (Array.isArray(this.props.children)) {
+	        var index = this.state.variants[this.state.value];
+	        return index !== undefined ? this.props.children[index] : null;
+	      }
+	      return this.props.children || null;
+	    }
 	    return this.state.variants[this.state.value] || null;
 	  }
 	});
@@ -280,14 +294,103 @@
 /***/ function(module, exports) {
 
 	// shim for using process in browser
-
 	var process = module.exports = {};
+
+	// cached from whatever global is present so that test runners that stub it
+	// don't break things.  But we need to wrap it in a try catch in case it is
+	// wrapped in strict mode code which doesn't define any globals.  It's inside a
+	// function because try/catches deoptimize in certain engines.
+
+	var cachedSetTimeout;
+	var cachedClearTimeout;
+
+	function defaultSetTimout() {
+	    throw new Error('setTimeout has not been defined');
+	}
+	function defaultClearTimeout () {
+	    throw new Error('clearTimeout has not been defined');
+	}
+	(function () {
+	    try {
+	        if (typeof setTimeout === 'function') {
+	            cachedSetTimeout = setTimeout;
+	        } else {
+	            cachedSetTimeout = defaultSetTimout;
+	        }
+	    } catch (e) {
+	        cachedSetTimeout = defaultSetTimout;
+	    }
+	    try {
+	        if (typeof clearTimeout === 'function') {
+	            cachedClearTimeout = clearTimeout;
+	        } else {
+	            cachedClearTimeout = defaultClearTimeout;
+	        }
+	    } catch (e) {
+	        cachedClearTimeout = defaultClearTimeout;
+	    }
+	} ())
+	function runTimeout(fun) {
+	    if (cachedSetTimeout === setTimeout) {
+	        //normal enviroments in sane situations
+	        return setTimeout(fun, 0);
+	    }
+	    // if setTimeout wasn't available but was latter defined
+	    if ((cachedSetTimeout === defaultSetTimout || !cachedSetTimeout) && setTimeout) {
+	        cachedSetTimeout = setTimeout;
+	        return setTimeout(fun, 0);
+	    }
+	    try {
+	        // when when somebody has screwed with setTimeout but no I.E. maddness
+	        return cachedSetTimeout(fun, 0);
+	    } catch(e){
+	        try {
+	            // When we are in I.E. but the script has been evaled so I.E. doesn't trust the global object when called normally
+	            return cachedSetTimeout.call(null, fun, 0);
+	        } catch(e){
+	            // same as above but when it's a version of I.E. that must have the global object for 'this', hopfully our context correct otherwise it will throw a global error
+	            return cachedSetTimeout.call(this, fun, 0);
+	        }
+	    }
+
+
+	}
+	function runClearTimeout(marker) {
+	    if (cachedClearTimeout === clearTimeout) {
+	        //normal enviroments in sane situations
+	        return clearTimeout(marker);
+	    }
+	    // if clearTimeout wasn't available but was latter defined
+	    if ((cachedClearTimeout === defaultClearTimeout || !cachedClearTimeout) && clearTimeout) {
+	        cachedClearTimeout = clearTimeout;
+	        return clearTimeout(marker);
+	    }
+	    try {
+	        // when when somebody has screwed with setTimeout but no I.E. maddness
+	        return cachedClearTimeout(marker);
+	    } catch (e){
+	        try {
+	            // When we are in I.E. but the script has been evaled so I.E. doesn't  trust the global object when called normally
+	            return cachedClearTimeout.call(null, marker);
+	        } catch (e){
+	            // same as above but when it's a version of I.E. that must have the global object for 'this', hopfully our context correct otherwise it will throw a global error.
+	            // Some versions of I.E. have different rules for clearTimeout vs setTimeout
+	            return cachedClearTimeout.call(this, marker);
+	        }
+	    }
+
+
+
+	}
 	var queue = [];
 	var draining = false;
 	var currentQueue;
 	var queueIndex = -1;
 
 	function cleanUpNextTick() {
+	    if (!draining || !currentQueue) {
+	        return;
+	    }
 	    draining = false;
 	    if (currentQueue.length) {
 	        queue = currentQueue.concat(queue);
@@ -303,7 +406,7 @@
 	    if (draining) {
 	        return;
 	    }
-	    var timeout = setTimeout(cleanUpNextTick);
+	    var timeout = runTimeout(cleanUpNextTick);
 	    draining = true;
 
 	    var len = queue.length;
@@ -320,7 +423,7 @@
 	    }
 	    currentQueue = null;
 	    draining = false;
-	    clearTimeout(timeout);
+	    runClearTimeout(timeout);
 	}
 
 	process.nextTick = function (fun) {
@@ -332,7 +435,7 @@
 	    }
 	    queue.push(new Item(fun, args));
 	    if (queue.length === 1 && !draining) {
-	        setTimeout(drainQueue, 0);
+	        runTimeout(drainQueue);
 	    }
 	};
 
@@ -400,20 +503,12 @@
 	var warning = emptyFunction;
 
 	if (process.env.NODE_ENV !== 'production') {
-	  warning = function (condition, format) {
-	    for (var _len = arguments.length, args = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
-	      args[_key - 2] = arguments[_key];
-	    }
+	  (function () {
+	    var printWarning = function printWarning(format) {
+	      for (var _len = arguments.length, args = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+	        args[_key - 1] = arguments[_key];
+	      }
 
-	    if (format === undefined) {
-	      throw new Error('`warning(condition, format, ...args)` requires a warning ' + 'message argument');
-	    }
-
-	    if (format.indexOf('Failed Composite propType: ') === 0) {
-	      return; // Ignore CompositeComponent proptype check.
-	    }
-
-	    if (!condition) {
 	      var argIndex = 0;
 	      var message = 'Warning: ' + format.replace(/%s/g, function () {
 	        return args[argIndex++];
@@ -427,8 +522,26 @@
 	        // to find the callsite that caused this warning to fire.
 	        throw new Error(message);
 	      } catch (x) {}
-	    }
-	  };
+	    };
+
+	    warning = function warning(condition, format) {
+	      if (format === undefined) {
+	        throw new Error('`warning(condition, format, ...args)` requires a warning ' + 'message argument');
+	      }
+
+	      if (format.indexOf('Failed Composite propType: ') === 0) {
+	        return; // Ignore CompositeComponent proptype check.
+	      }
+
+	      if (!condition) {
+	        for (var _len2 = arguments.length, args = Array(_len2 > 2 ? _len2 - 2 : 0), _key2 = 2; _key2 < _len2; _key2++) {
+	          args[_key2 - 2] = arguments[_key2];
+	        }
+
+	        printWarning.apply(undefined, [format].concat(args));
+	      }
+	    };
+	  })();
 	}
 
 	module.exports = warning;
@@ -448,6 +561,7 @@
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
+	 * 
 	 */
 
 	function makeEmptyFunction(arg) {
@@ -461,7 +575,7 @@
 	 * primarily useful idiomatically for overridable function endpoints which
 	 * always need to be callable, since JS lacks a null-call idiom ala Cocoa.
 	 */
-	function emptyFunction() {}
+	var emptyFunction = function emptyFunction() {};
 
 	emptyFunction.thatReturns = makeEmptyFunction;
 	emptyFunction.thatReturnsFalse = makeEmptyFunction(false);
@@ -696,7 +810,7 @@
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
-	 * Copyright (c) 2014-2015, Facebook, Inc.
+	 * Copyright (c) 2014-present, Facebook, Inc.
 	 * All rights reserved.
 	 *
 	 * This source code is licensed under the BSD-style license found in the
@@ -705,7 +819,8 @@
 	 */
 
 	var fbemitter = {
-	  EventEmitter: __webpack_require__(11)
+	  EventEmitter: __webpack_require__(11),
+	  EmitterSubscription : __webpack_require__(12)
 	};
 
 	module.exports = fbemitter;
@@ -716,7 +831,7 @@
 /***/ function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(process) {/**
-	 * Copyright (c) 2014-2015, Facebook, Inc.
+	 * Copyright (c) 2014-present, Facebook, Inc.
 	 * All rights reserved.
 	 *
 	 * This source code is licensed under the BSD-style license found in the
@@ -734,7 +849,7 @@
 	var EmitterSubscription = __webpack_require__(12);
 	var EventSubscriptionVendor = __webpack_require__(14);
 
-	var emptyFunction = __webpack_require__(16);
+	var emptyFunction = __webpack_require__(7);
 	var invariant = __webpack_require__(15);
 
 	/**
@@ -913,7 +1028,7 @@
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
-	 * Copyright (c) 2014-2015, Facebook, Inc.
+	 * Copyright (c) 2014-present, Facebook, Inc.
 	 * All rights reserved.
 	 *
 	 * This source code is licensed under the BSD-style license found in the
@@ -966,7 +1081,7 @@
 /***/ function(module, exports) {
 
 	/**
-	 * Copyright (c) 2014-2015, Facebook, Inc.
+	 * Copyright (c) 2014-present, Facebook, Inc.
 	 * All rights reserved.
 	 *
 	 * This source code is licensed under the BSD-style license found in the
@@ -1020,7 +1135,7 @@
 /***/ function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(process) {/**
-	 * Copyright (c) 2014-2015, Facebook, Inc.
+	 * Copyright (c) 2014-present, Facebook, Inc.
 	 * All rights reserved.
 	 *
 	 * This source code is licensed under the BSD-style license found in the
@@ -1129,7 +1244,7 @@
 /***/ function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(process) {/**
-	 * Copyright 2013-2015, Facebook, Inc.
+	 * Copyright (c) 2013-present, Facebook, Inc.
 	 * All rights reserved.
 	 *
 	 * This source code is licensed under the BSD-style license found in the
@@ -1181,57 +1296,15 @@
 
 /***/ },
 /* 16 */
-/***/ function(module, exports) {
-
-	/**
-	 * Copyright 2013-2015, Facebook, Inc.
-	 * All rights reserved.
-	 *
-	 * This source code is licensed under the BSD-style license found in the
-	 * LICENSE file in the root directory of this source tree. An additional grant
-	 * of patent rights can be found in the PATENTS file in the same directory.
-	 *
-	 */
-
-	"use strict";
-
-	function makeEmptyFunction(arg) {
-	  return function () {
-	    return arg;
-	  };
-	}
-
-	/**
-	 * This function accepts and discards inputs; it has no side effects. This is
-	 * primarily useful idiomatically for overridable function endpoints which
-	 * always need to be callable, since JS lacks a null-call idiom ala Cocoa.
-	 */
-	function emptyFunction() {}
-
-	emptyFunction.thatReturns = makeEmptyFunction;
-	emptyFunction.thatReturnsFalse = makeEmptyFunction(false);
-	emptyFunction.thatReturnsTrue = makeEmptyFunction(true);
-	emptyFunction.thatReturnsNull = makeEmptyFunction(null);
-	emptyFunction.thatReturnsThis = function () {
-	  return this;
-	};
-	emptyFunction.thatReturnsArgument = function (arg) {
-	  return arg;
-	};
-
-	module.exports = emptyFunction;
-
-/***/ },
-/* 17 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(global) {"use strict";
 
-	module.exports = global["Variant"] = __webpack_require__(18);
+	module.exports = global["Variant"] = __webpack_require__(17);
 	/* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }())))
 
 /***/ },
-/* 18 */
+/* 17 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -1266,7 +1339,7 @@
 	module.exports = exports['default'];
 
 /***/ },
-/* 19 */
+/* 18 */
 /***/ function(module, exports) {
 
 	/* WEBPACK VAR INJECTION */(function(global) {"use strict";
@@ -1301,16 +1374,16 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }())))
 
 /***/ },
-/* 20 */
+/* 19 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(global) {"use strict";
 
-	module.exports = global["experimentDebugger"] = __webpack_require__(21);
+	module.exports = global["experimentDebugger"] = __webpack_require__(20);
 	/* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }())))
 
 /***/ },
-/* 21 */
+/* 20 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(process) {'use strict';
@@ -1319,7 +1392,7 @@
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _reactDom = __webpack_require__(22);
+	var _reactDom = __webpack_require__(21);
 
 	var _reactDom2 = _interopRequireDefault(_reactDom);
 
@@ -1327,7 +1400,7 @@
 
 	var _emitter2 = _interopRequireDefault(_emitter);
 
-	var _ExecutionEnvironment = __webpack_require__(23);
+	var _ExecutionEnvironment = __webpack_require__(22);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -1527,13 +1600,13 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(5)))
 
 /***/ },
-/* 22 */
+/* 21 */
 /***/ function(module, exports) {
 
 	module.exports = ReactDOM;
 
 /***/ },
-/* 23 */
+/* 22 */
 /***/ function(module, exports) {
 
 	/**
@@ -1573,16 +1646,16 @@
 	module.exports = ExecutionEnvironment;
 
 /***/ },
-/* 24 */
+/* 23 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(global) {"use strict";
 
-	module.exports = global["mixpanelHelper"] = __webpack_require__(25);
+	module.exports = global["mixpanelHelper"] = __webpack_require__(24);
 	/* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }())))
 
 /***/ },
-/* 25 */
+/* 24 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -1595,7 +1668,7 @@
 
 	var _emitter2 = _interopRequireDefault(_emitter);
 
-	var _ExecutionEnvironment = __webpack_require__(23);
+	var _ExecutionEnvironment = __webpack_require__(22);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -1643,16 +1716,16 @@
 	module.exports = exports['default'];
 
 /***/ },
-/* 26 */
+/* 25 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(global) {"use strict";
 
-	module.exports = global["segmentHelper"] = __webpack_require__(27);
+	module.exports = global["segmentHelper"] = __webpack_require__(26);
 	/* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }())))
 
 /***/ },
-/* 27 */
+/* 26 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -1665,7 +1738,7 @@
 
 	var _emitter2 = _interopRequireDefault(_emitter);
 
-	var _ExecutionEnvironment = __webpack_require__(23);
+	var _ExecutionEnvironment = __webpack_require__(22);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 

--- a/test/browser/core.test.jsx
+++ b/test/browser/core.test.jsx
@@ -154,7 +154,6 @@ describe("Core Experiment", function() {
     assert.equal(elementB, null);
 
     let elementAText = document.getElementById('variant-a-text');
-    console.log(elementAText.textContent);
     assert.equal(elementAText.textContent, variantAText);
 
     variantAText = "Initial text 2";

--- a/test/browser/core.test.jsx
+++ b/test/browser/core.test.jsx
@@ -103,5 +103,67 @@ describe("Core Experiment", function() {
     assert.notEqual(elementB, null);
     ReactDOM.unmountComponentAtNode(container);
   }));
+  it("should update children components when their props change", co.wrap(function *(){
+    let experimentName = UUID.v4();
+
+    let SubComponent = React.createClass({
+      render(){
+        return (
+            <div id="variant-a">
+              <span id="variant-a-text">{this.props.text}</span>
+            </div>
+        )
+      }
+    });
+
+    let variantAText = "Initial text";
+
+    let renderHelper = {
+      init(callback) {
+        this.callback = callback;
+      },
+      reRender() {
+        this.callback();
+      }
+    };
+
+    let App = React.createClass({
+      componentDidMount(){
+        renderHelper.init(this.callback);
+      },
+      callback() {
+        this.forceUpdate();
+      },
+      render(){
+        return (
+          <Experiment name={experimentName} value="A" isContentDynamic>
+            <Variant name="A">
+              <SubComponent text={variantAText}/>
+            </Variant>
+            <Variant name="B"><div id="variant-b" /></Variant>
+          </Experiment>
+        )
+      }
+    });
+    yield new Promise(function(resolve, reject){
+      ReactDOM.render(<App />, container, resolve);
+    });
+    let elementA = document.getElementById('variant-a');
+    let elementB = document.getElementById('variant-b');
+    assert.notEqual(elementA, null);
+    assert.equal(elementB, null);
+
+    let elementAText = document.getElementById('variant-a-text');
+    console.log(elementAText.textContent);
+    assert.equal(elementAText.textContent, variantAText);
+
+    variantAText = "Initial text 2";
+    renderHelper.reRender();
+    elementAText = document.getElementById('variant-a-text');
+
+    assert.equal(elementAText.textContent, variantAText);
+
+    ReactDOM.unmountComponentAtNode(container);
+  }));
 });
 


### PR DESCRIPTION
This PR will allow components inside Variants to be re-rendered when their props/state changes

* In `CoreExperiment` render method use element from `this.props.children` and variant index from `this.state.variants` to render updated component.
* `isContentDynamic` prop added to `Experiment` component

Resolves #10 