### PR TITLE
fixing memory leaks while server rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ var session = require('express-session');
 var React = require("react");
 var ReactDOMServer = require("react-dom/server");
 var Component = require("./Component.jsx");
+var abEmitter = require("react-ab-test/lib/emitter")
 
 var app = express();
 
@@ -328,6 +329,7 @@ app.use(session({
 app.get('/', function (req, res) {
   var reactElement = React.createElement(Component, {userIdentifier: req.sessionID});
   var reactString = ReactDOMServer.renderToString(reactElement);
+  abEmitter.rewind();
   res.render('template', {
     sessionID: req.sessionID,
     reactOutput: reactString
@@ -338,6 +340,8 @@ app.use(express.static('www'));
 
 app.listen(8080);
 ```
+
+Remember to call `abEmitter.rewind()` to prevent memory leaks.
 
 An [EJS](https://github.com/mde/ejs) template in [`template.ejs`](https://github.com/pushtell/react-ab-test/blob/master/examples/isomorphic/views/template.ejs):
 

--- a/examples/isomorphic/server.js
+++ b/examples/isomorphic/server.js
@@ -5,6 +5,7 @@ var session = require('express-session');
 var React = require("react");
 var ReactDOMServer = require("react-dom/server");
 var Component = require("./Component.jsx");
+var abTestsEmitter = require("../../lib/emitter");
 
 var app = express();
 
@@ -19,6 +20,9 @@ app.use(session({
 app.get('/', function (req, res) {
   var reactElement = React.createElement(Component, {userIdentifier: req.sessionID});
   var reactString = ReactDOMServer.renderToString(reactElement);
+
+  // important to prevent memory leaks
+  abTestsEmitter.rewind();
   res.render('template', {
     sessionID: req.sessionID,
     reactOutput: reactString

--- a/lib/emitter.js
+++ b/lib/emitter.js
@@ -51,6 +51,11 @@ PushtellEventEmitter.prototype._reset = function () {
   playedExperiments = {};
 };
 
+PushtellEventEmitter.prototype.rewind = function () {
+  this._reset();
+  emitter.removeAllListeners();
+};
+
 PushtellEventEmitter.prototype._incrementActiveExperiments = function (experimentName) {
   activeExperiments[experimentName] = activeExperiments[experimentName] || 0;
   activeExperiments[experimentName] += 1;

--- a/src/emitter.jsx
+++ b/src/emitter.jsx
@@ -45,6 +45,11 @@ PushtellEventEmitter.prototype._reset = function(){
   playedExperiments = {};
 }
 
+PushtellEventEmitter.prototype.rewind = function() {
+  this._reset();
+  emitter.removeAllListeners();
+}
+
 PushtellEventEmitter.prototype._incrementActiveExperiments = function(experimentName) {
   activeExperiments[experimentName] = activeExperiments[experimentName] || 0;
   activeExperiments[experimentName] += 1;

--- a/standalone.min.js
+++ b/standalone.min.js
@@ -48,11 +48,11 @@
 
 	module.exports = {
 	  Experiment: __webpack_require__(1),
-	  Variant: __webpack_require__(17),
+	  Variant: __webpack_require__(16),
 	  emitter: __webpack_require__(8),
-	  experimentDebugger: __webpack_require__(20),
-	  mixpanelHelper: __webpack_require__(24),
-	  segmentHelper: __webpack_require__(26)
+	  experimentDebugger: __webpack_require__(19),
+	  mixpanelHelper: __webpack_require__(23),
+	  segmentHelper: __webpack_require__(25)
 	};
 
 /***/ },
@@ -88,7 +88,7 @@
 
 	var _emitter2 = _interopRequireDefault(_emitter);
 
-	var _crc = __webpack_require__(19);
+	var _crc = __webpack_require__(18);
 
 	var _crc2 = _interopRequireDefault(_crc);
 
@@ -200,7 +200,7 @@
 
 	var _emitter2 = _interopRequireDefault(_emitter);
 
-	var _Variant = __webpack_require__(17);
+	var _Variant = __webpack_require__(16);
 
 	var _Variant2 = _interopRequireDefault(_Variant);
 
@@ -289,14 +289,103 @@
 /***/ function(module, exports) {
 
 	// shim for using process in browser
-
 	var process = module.exports = {};
+
+	// cached from whatever global is present so that test runners that stub it
+	// don't break things.  But we need to wrap it in a try catch in case it is
+	// wrapped in strict mode code which doesn't define any globals.  It's inside a
+	// function because try/catches deoptimize in certain engines.
+
+	var cachedSetTimeout;
+	var cachedClearTimeout;
+
+	function defaultSetTimout() {
+	    throw new Error('setTimeout has not been defined');
+	}
+	function defaultClearTimeout () {
+	    throw new Error('clearTimeout has not been defined');
+	}
+	(function () {
+	    try {
+	        if (typeof setTimeout === 'function') {
+	            cachedSetTimeout = setTimeout;
+	        } else {
+	            cachedSetTimeout = defaultSetTimout;
+	        }
+	    } catch (e) {
+	        cachedSetTimeout = defaultSetTimout;
+	    }
+	    try {
+	        if (typeof clearTimeout === 'function') {
+	            cachedClearTimeout = clearTimeout;
+	        } else {
+	            cachedClearTimeout = defaultClearTimeout;
+	        }
+	    } catch (e) {
+	        cachedClearTimeout = defaultClearTimeout;
+	    }
+	} ())
+	function runTimeout(fun) {
+	    if (cachedSetTimeout === setTimeout) {
+	        //normal enviroments in sane situations
+	        return setTimeout(fun, 0);
+	    }
+	    // if setTimeout wasn't available but was latter defined
+	    if ((cachedSetTimeout === defaultSetTimout || !cachedSetTimeout) && setTimeout) {
+	        cachedSetTimeout = setTimeout;
+	        return setTimeout(fun, 0);
+	    }
+	    try {
+	        // when when somebody has screwed with setTimeout but no I.E. maddness
+	        return cachedSetTimeout(fun, 0);
+	    } catch(e){
+	        try {
+	            // When we are in I.E. but the script has been evaled so I.E. doesn't trust the global object when called normally
+	            return cachedSetTimeout.call(null, fun, 0);
+	        } catch(e){
+	            // same as above but when it's a version of I.E. that must have the global object for 'this', hopfully our context correct otherwise it will throw a global error
+	            return cachedSetTimeout.call(this, fun, 0);
+	        }
+	    }
+
+
+	}
+	function runClearTimeout(marker) {
+	    if (cachedClearTimeout === clearTimeout) {
+	        //normal enviroments in sane situations
+	        return clearTimeout(marker);
+	    }
+	    // if clearTimeout wasn't available but was latter defined
+	    if ((cachedClearTimeout === defaultClearTimeout || !cachedClearTimeout) && clearTimeout) {
+	        cachedClearTimeout = clearTimeout;
+	        return clearTimeout(marker);
+	    }
+	    try {
+	        // when when somebody has screwed with setTimeout but no I.E. maddness
+	        return cachedClearTimeout(marker);
+	    } catch (e){
+	        try {
+	            // When we are in I.E. but the script has been evaled so I.E. doesn't  trust the global object when called normally
+	            return cachedClearTimeout.call(null, marker);
+	        } catch (e){
+	            // same as above but when it's a version of I.E. that must have the global object for 'this', hopfully our context correct otherwise it will throw a global error.
+	            // Some versions of I.E. have different rules for clearTimeout vs setTimeout
+	            return cachedClearTimeout.call(this, marker);
+	        }
+	    }
+
+
+
+	}
 	var queue = [];
 	var draining = false;
 	var currentQueue;
 	var queueIndex = -1;
 
 	function cleanUpNextTick() {
+	    if (!draining || !currentQueue) {
+	        return;
+	    }
 	    draining = false;
 	    if (currentQueue.length) {
 	        queue = currentQueue.concat(queue);
@@ -312,7 +401,7 @@
 	    if (draining) {
 	        return;
 	    }
-	    var timeout = setTimeout(cleanUpNextTick);
+	    var timeout = runTimeout(cleanUpNextTick);
 	    draining = true;
 
 	    var len = queue.length;
@@ -329,7 +418,7 @@
 	    }
 	    currentQueue = null;
 	    draining = false;
-	    clearTimeout(timeout);
+	    runClearTimeout(timeout);
 	}
 
 	process.nextTick = function (fun) {
@@ -341,7 +430,7 @@
 	    }
 	    queue.push(new Item(fun, args));
 	    if (queue.length === 1 && !draining) {
-	        setTimeout(drainQueue, 0);
+	        runTimeout(drainQueue);
 	    }
 	};
 
@@ -409,20 +498,12 @@
 	var warning = emptyFunction;
 
 	if (process.env.NODE_ENV !== 'production') {
-	  warning = function (condition, format) {
-	    for (var _len = arguments.length, args = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
-	      args[_key - 2] = arguments[_key];
-	    }
+	  (function () {
+	    var printWarning = function printWarning(format) {
+	      for (var _len = arguments.length, args = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+	        args[_key - 1] = arguments[_key];
+	      }
 
-	    if (format === undefined) {
-	      throw new Error('`warning(condition, format, ...args)` requires a warning ' + 'message argument');
-	    }
-
-	    if (format.indexOf('Failed Composite propType: ') === 0) {
-	      return; // Ignore CompositeComponent proptype check.
-	    }
-
-	    if (!condition) {
 	      var argIndex = 0;
 	      var message = 'Warning: ' + format.replace(/%s/g, function () {
 	        return args[argIndex++];
@@ -436,8 +517,26 @@
 	        // to find the callsite that caused this warning to fire.
 	        throw new Error(message);
 	      } catch (x) {}
-	    }
-	  };
+	    };
+
+	    warning = function warning(condition, format) {
+	      if (format === undefined) {
+	        throw new Error('`warning(condition, format, ...args)` requires a warning ' + 'message argument');
+	      }
+
+	      if (format.indexOf('Failed Composite propType: ') === 0) {
+	        return; // Ignore CompositeComponent proptype check.
+	      }
+
+	      if (!condition) {
+	        for (var _len2 = arguments.length, args = Array(_len2 > 2 ? _len2 - 2 : 0), _key2 = 2; _key2 < _len2; _key2++) {
+	          args[_key2 - 2] = arguments[_key2];
+	        }
+
+	        printWarning.apply(undefined, [format].concat(args));
+	      }
+	    };
+	  })();
 	}
 
 	module.exports = warning;
@@ -457,6 +556,7 @@
 	 * LICENSE file in the root directory of this source tree. An additional grant
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
+	 * 
 	 */
 
 	function makeEmptyFunction(arg) {
@@ -470,7 +570,7 @@
 	 * primarily useful idiomatically for overridable function endpoints which
 	 * always need to be callable, since JS lacks a null-call idiom ala Cocoa.
 	 */
-	function emptyFunction() {}
+	var emptyFunction = function emptyFunction() {};
 
 	emptyFunction.thatReturns = makeEmptyFunction;
 	emptyFunction.thatReturnsFalse = makeEmptyFunction(false);
@@ -549,6 +649,11 @@
 	  activeExperiments = {};
 	  experimentsWithDefinedVariants = {};
 	  playedExperiments = {};
+	};
+
+	PushtellEventEmitter.prototype.rewind = function () {
+	  this._reset();
+	  emitter.removeAllListeners();
 	};
 
 	PushtellEventEmitter.prototype._incrementActiveExperiments = function (experimentName) {
@@ -705,7 +810,7 @@
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
-	 * Copyright (c) 2014-2015, Facebook, Inc.
+	 * Copyright (c) 2014-present, Facebook, Inc.
 	 * All rights reserved.
 	 *
 	 * This source code is licensed under the BSD-style license found in the
@@ -714,7 +819,8 @@
 	 */
 
 	var fbemitter = {
-	  EventEmitter: __webpack_require__(11)
+	  EventEmitter: __webpack_require__(11),
+	  EmitterSubscription : __webpack_require__(12)
 	};
 
 	module.exports = fbemitter;
@@ -725,7 +831,7 @@
 /***/ function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(process) {/**
-	 * Copyright (c) 2014-2015, Facebook, Inc.
+	 * Copyright (c) 2014-present, Facebook, Inc.
 	 * All rights reserved.
 	 *
 	 * This source code is licensed under the BSD-style license found in the
@@ -743,7 +849,7 @@
 	var EmitterSubscription = __webpack_require__(12);
 	var EventSubscriptionVendor = __webpack_require__(14);
 
-	var emptyFunction = __webpack_require__(16);
+	var emptyFunction = __webpack_require__(7);
 	var invariant = __webpack_require__(15);
 
 	/**
@@ -922,7 +1028,7 @@
 /***/ function(module, exports, __webpack_require__) {
 
 	/**
-	 * Copyright (c) 2014-2015, Facebook, Inc.
+	 * Copyright (c) 2014-present, Facebook, Inc.
 	 * All rights reserved.
 	 *
 	 * This source code is licensed under the BSD-style license found in the
@@ -975,7 +1081,7 @@
 /***/ function(module, exports) {
 
 	/**
-	 * Copyright (c) 2014-2015, Facebook, Inc.
+	 * Copyright (c) 2014-present, Facebook, Inc.
 	 * All rights reserved.
 	 *
 	 * This source code is licensed under the BSD-style license found in the
@@ -1029,7 +1135,7 @@
 /***/ function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(process) {/**
-	 * Copyright (c) 2014-2015, Facebook, Inc.
+	 * Copyright (c) 2014-present, Facebook, Inc.
 	 * All rights reserved.
 	 *
 	 * This source code is licensed under the BSD-style license found in the
@@ -1138,7 +1244,7 @@
 /***/ function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(process) {/**
-	 * Copyright 2013-2015, Facebook, Inc.
+	 * Copyright (c) 2013-present, Facebook, Inc.
 	 * All rights reserved.
 	 *
 	 * This source code is licensed under the BSD-style license found in the
@@ -1160,12 +1266,18 @@
 	 * will remain to ensure logic does not differ in production.
 	 */
 
-	function invariant(condition, format, a, b, c, d, e, f) {
-	  if (process.env.NODE_ENV !== 'production') {
+	var validateFormat = function validateFormat(format) {};
+
+	if (process.env.NODE_ENV !== 'production') {
+	  validateFormat = function validateFormat(format) {
 	    if (format === undefined) {
 	      throw new Error('invariant requires an error message argument');
 	    }
-	  }
+	  };
+	}
+
+	function invariant(condition, format, a, b, c, d, e, f) {
+	  validateFormat(format);
 
 	  if (!condition) {
 	    var error;
@@ -1190,57 +1302,15 @@
 
 /***/ },
 /* 16 */
-/***/ function(module, exports) {
-
-	/**
-	 * Copyright 2013-2015, Facebook, Inc.
-	 * All rights reserved.
-	 *
-	 * This source code is licensed under the BSD-style license found in the
-	 * LICENSE file in the root directory of this source tree. An additional grant
-	 * of patent rights can be found in the PATENTS file in the same directory.
-	 *
-	 */
-
-	"use strict";
-
-	function makeEmptyFunction(arg) {
-	  return function () {
-	    return arg;
-	  };
-	}
-
-	/**
-	 * This function accepts and discards inputs; it has no side effects. This is
-	 * primarily useful idiomatically for overridable function endpoints which
-	 * always need to be callable, since JS lacks a null-call idiom ala Cocoa.
-	 */
-	function emptyFunction() {}
-
-	emptyFunction.thatReturns = makeEmptyFunction;
-	emptyFunction.thatReturnsFalse = makeEmptyFunction(false);
-	emptyFunction.thatReturnsTrue = makeEmptyFunction(true);
-	emptyFunction.thatReturnsNull = makeEmptyFunction(null);
-	emptyFunction.thatReturnsThis = function () {
-	  return this;
-	};
-	emptyFunction.thatReturnsArgument = function (arg) {
-	  return arg;
-	};
-
-	module.exports = emptyFunction;
-
-/***/ },
-/* 17 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(global) {"use strict";
 
-	module.exports = global["Variant"] = __webpack_require__(18);
+	module.exports = global["Variant"] = __webpack_require__(17);
 	/* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }())))
 
 /***/ },
-/* 18 */
+/* 17 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -1275,7 +1345,7 @@
 	module.exports = exports['default'];
 
 /***/ },
-/* 19 */
+/* 18 */
 /***/ function(module, exports) {
 
 	/* WEBPACK VAR INJECTION */(function(global) {"use strict";
@@ -1310,16 +1380,16 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }())))
 
 /***/ },
-/* 20 */
+/* 19 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(global) {"use strict";
 
-	module.exports = global["experimentDebugger"] = __webpack_require__(21);
+	module.exports = global["experimentDebugger"] = __webpack_require__(20);
 	/* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }())))
 
 /***/ },
-/* 21 */
+/* 20 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(process) {'use strict';
@@ -1328,7 +1398,7 @@
 
 	var _react2 = _interopRequireDefault(_react);
 
-	var _reactDom = __webpack_require__(22);
+	var _reactDom = __webpack_require__(21);
 
 	var _reactDom2 = _interopRequireDefault(_reactDom);
 
@@ -1336,7 +1406,7 @@
 
 	var _emitter2 = _interopRequireDefault(_emitter);
 
-	var _ExecutionEnvironment = __webpack_require__(23);
+	var _ExecutionEnvironment = __webpack_require__(22);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -1459,7 +1529,7 @@
 	            _react2.default.createElement(
 	              'div',
 	              { className: 'pushtell-close', onClick: this.toggleVisibility },
-	              '×'
+	              '\xD7'
 	            ),
 	            experimentNames.map(function (experimentName) {
 	              var variantNames = Object.keys(_this.state.experiments[experimentName]);
@@ -1536,13 +1606,13 @@
 	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(5)))
 
 /***/ },
-/* 22 */
+/* 21 */
 /***/ function(module, exports) {
 
 	module.exports = ReactDOM;
 
 /***/ },
-/* 23 */
+/* 22 */
 /***/ function(module, exports) {
 
 	/**
@@ -1582,16 +1652,16 @@
 	module.exports = ExecutionEnvironment;
 
 /***/ },
-/* 24 */
+/* 23 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(global) {"use strict";
 
-	module.exports = global["mixpanelHelper"] = __webpack_require__(25);
+	module.exports = global["mixpanelHelper"] = __webpack_require__(24);
 	/* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }())))
 
 /***/ },
-/* 25 */
+/* 24 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -1604,7 +1674,7 @@
 
 	var _emitter2 = _interopRequireDefault(_emitter);
 
-	var _ExecutionEnvironment = __webpack_require__(23);
+	var _ExecutionEnvironment = __webpack_require__(22);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -1652,16 +1722,16 @@
 	module.exports = exports['default'];
 
 /***/ },
-/* 26 */
+/* 25 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(global) {"use strict";
 
-	module.exports = global["segmentHelper"] = __webpack_require__(27);
+	module.exports = global["segmentHelper"] = __webpack_require__(26);
 	/* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }())))
 
 /***/ },
-/* 27 */
+/* 26 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -1674,7 +1744,7 @@
 
 	var _emitter2 = _interopRequireDefault(_emitter);
 
-	var _ExecutionEnvironment = __webpack_require__(23);
+	var _ExecutionEnvironment = __webpack_require__(22);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 


### PR DESCRIPTION
This PR fixes memory leaks during server rendering https://github.com/pushtell/react-ab-test/issues/16
I've added .rewind() method to emitter to cleanup all the subscriptions. Calling this after ReactDOMServer.renderToString is preventing leaks (just like react-helmet)